### PR TITLE
Increase MAX_COMBINED_LEN back to 4096, and optimize restrict_file_open.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,20 @@
 # Paths and variables
 BPFOBJ = pkg/syscallfilter/syscallfilter_x86_bpfel.o pkg/privilege/privilege_x86_bpfel.o pkg/fileaccess/fileaccess_x86_bpfel.o
 BPFOBJ_GO = pkg/syscallfilter/syscallfilter_x86_bpfel.go pkg/privilege/privilege_x86_bpfel.go pkg/fileaccess/fileaccess_x86_bpfel.go
-VMLINUX = vmlinux.h
 EBPF_DIR = src
+VMLINUX = $(EBPF_DIR)/vmlinux.h
 GO_CLI_DIR = .
 CLI_BINARY = heimdall
 
 # Default target
-all: vmlinux build-bpf-obj build-cli
+all: $(VMLINUX) build-bpf-obj build-cli
 
 # Generate vmlinux.h using bpftool
-vmlinux:
-	bpftool btf dump file /sys/kernel/btf/vmlinux format c > $(EBPF_DIR)/$(VMLINUX)
+$(VMLINUX):
+	bpftool btf dump file /sys/kernel/btf/vmlinux format c > $(VMLINUX)
 
 # Compile eBPF program using "go generate"
-build-bpf-obj: vmlinux
+build-bpf-obj: $(VMLINUX)
 	go generate
 
 # Build the Go CLI userspace binary
@@ -35,7 +35,7 @@ lint:
 
 # Clean generated files
 clean:
-	rm -f $(EBPF_DIR)/$(VMLINUX) $(BPFOBJ) $(BPFOBJ_GO) $(CLI_BINARY)
+	rm -f $(VMLINUX) $(BPFOBJ) $(BPFOBJ_GO) $(CLI_BINARY)
 
 # Clean and rebuild everything
 rebuild: clean all
@@ -56,4 +56,4 @@ help:
 	@echo "  rebuild       Clean and build everything from scratch"
 	@echo "  help          Show this help message"
 
-.PHONY: all vmlinux build-bpf-obj build-cli fmt test lint clean rebuild help
+.PHONY: all build-bpf-obj build-cli fmt test lint clean rebuild help

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ make all
 ```
 
 
-This is will give an executable file called `syscall_blocker`
+This is will give an executable file called `heimdall`
 ```bash
-sudo ./syscall_blocker --help
+sudo ./heimdall --help
 ```
 
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,6 +39,11 @@ var rootCmd = &cobra.Command{
 		flagPaths, _ := cmd.Flags().GetStringSlice("file-path")
 		yamlPath, _ := cmd.Flags().GetString("yaml")
 
+		// Remove resource limits for kernels <5.11.
+		if err := rlimit.RemoveMemlock(); err != nil {
+			log.Fatal("Removing memlock:", err)
+		}
+
 		var cfg Config
 		if yamlPath != "" {
 			data, err := os.ReadFile(yamlPath)
@@ -138,11 +143,6 @@ func Execute() {
 	rootCmd.Flags().BoolP("block-privilege-escalation", "p", false, "Block Privilege Escalation attempts for the container")
 	rootCmd.Flags().StringSliceP("file-path", "f", []string{}, "File path to block")
 	rootCmd.Flags().StringP("yaml", "y", "", "Path to YAML config file with container_id, block_syscalls, block_privilege_escalation, file_paths")
-
-	// Remove resource limits for kernels <5.11.
-	if err := rlimit.RemoveMemlock(); err != nil {
-		log.Fatal("Removing memlock:", err)
-	}
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)

--- a/pkg/fileaccess/fileaccess.go
+++ b/pkg/fileaccess/fileaccess.go
@@ -34,10 +34,11 @@ func BlockFileOpen(ctx context.Context, wg *sync.WaitGroup, cgroupID uint64, fil
 	defer kp.Close()
 
 	// Create filter and put in map
-	var val fileaccessFilePath
 	entries := len(filePath)
-	for i := 0; i < entries; i++ {
-		for j := 0; j < len(filePath[i]); j++ {
+	for i := range entries {
+		val := fileaccessFilePath{}
+
+		for j := range len(filePath[i]) {
 			val.Path[j] = int8(filePath[i][j])
 		}
 		val.CgroupId = cgroupID
@@ -47,7 +48,6 @@ func BlockFileOpen(ctx context.Context, wg *sync.WaitGroup, cgroupID uint64, fil
 		} else {
 			log.Printf("Added %s to Blocked File Paths", filePath[i])
 		}
-		val = fileaccessFilePath{}
 	}
 
 	// Create new reader to read from perf buffer

--- a/src/common.h
+++ b/src/common.h
@@ -7,7 +7,7 @@
 
 #define SIGKILL 9
 #define TASK_COMM_LEN 16
-#define MAX_COMBINED_LEN 368
+#define MAX_COMBINED_LEN 4096
 
 struct process_info
 {


### PR DESCRIPTION
This change increases `MAX_COMBINED_LEN` back to 4096 by moving the process_info structures to maps. We also optimize the `restrict_file_open` function by introducing a bunch of early exits, and optimizing the loop path, where it would be spending most of the time.