### PR TITLE
Fix broken logs by increasing buffer size

### DIFF
--- a/pkg/fileaccess/fileaccess.go
+++ b/pkg/fileaccess/fileaccess.go
@@ -3,8 +3,8 @@ package fileaccess
 import (
 	"context"
 	"log"
-	"os"
 	"sync"
+	"unsafe"
 
 	"bytes"
 	"encoding/binary"
@@ -51,7 +51,7 @@ func BlockFileOpen(ctx context.Context, wg *sync.WaitGroup, cgroupID uint64, fil
 	}
 
 	// Create new reader to read from perf buffer
-	rd, err := perf.NewReader(objs.FileAccessEvents, os.Getpagesize())
+	rd, err := perf.NewReader(objs.FileAccessEvents, int(10*unsafe.Sizeof(fileaccessProcessInfo{})))
 	if err != nil {
 		log.Fatalf("creating perf event reader: %s", err)
 	}

--- a/pkg/privilege/privilege.go
+++ b/pkg/privilege/privilege.go
@@ -6,8 +6,8 @@ import (
 	"encoding/binary"
 	"errors"
 	"log"
-	"os"
 	"sync"
+	"unsafe"
 
 	"github.com/cilium/ebpf/link"
 	"github.com/cilium/ebpf/perf"
@@ -47,7 +47,7 @@ func BlockPrivilegeEscalation(ctx context.Context, wg *sync.WaitGroup, cgroupID 
 	}
 
 	// Create new reader to read from perf buffer
-	rd, err := perf.NewReader(objs.PrivilegeEscalationEvents, os.Getpagesize())
+	rd, err := perf.NewReader(objs.PrivilegeEscalationEvents, int(10*unsafe.Sizeof(privilegeProcessInfo{})))
 	if err != nil {
 		log.Fatalf("creating perf event reader: %s", err)
 	}

--- a/pkg/syscallfilter/syscallfilter.go
+++ b/pkg/syscallfilter/syscallfilter.go
@@ -6,8 +6,8 @@ import (
 	"encoding/binary"
 	"errors"
 	"log"
-	"os"
 	"sync"
+	"unsafe"
 
 	"github.com/Devaansh-Kumar/Heimdall/pkg/x64"
 	"github.com/cilium/ebpf/link"
@@ -52,7 +52,7 @@ func BlockSystemCall(ctx context.Context, wg *sync.WaitGroup, sysCallList []uint
 	}
 
 	// Create new reader to read from perf buffer
-	rd, err := perf.NewReader(objs.SyscallEvents, os.Getpagesize())
+	rd, err := perf.NewReader(objs.SyscallEvents, int(10*unsafe.Sizeof(syscallfilterProcessInfo{})))
 	if err != nil {
 		log.Fatalf("creating perf event reader: %s", err)
 	}


### PR DESCRIPTION
Due to increasing MAX_COMBINED_LEN, the size of
the object was greater than a single page, we now
keep enough space to store 10 such objects.